### PR TITLE
docs: add Rocket Proxy as a free iOS/macOS client and an Apple TV option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml
 | Platform | Recommended App | Download |
 |----------|----------------|----------|
 | **Windows** | v2rayN / Clash Verge Rev | [v2rayN](https://github.com/2dust/v2rayN/releases) / [Clash Verge Rev](https://github.com/clash-verge-rev/clash-verge-rev/releases) |
-| **macOS** | Clash Verge Rev | [Clash Verge Rev](https://github.com/clash-verge-rev/clash-verge-rev/releases) |
+| **macOS** | Clash Verge Rev / Rocket Proxy | [Clash Verge Rev](https://github.com/clash-verge-rev/clash-verge-rev/releases) / [Rocket Proxy](https://apps.apple.com/app/id6785291194) |
 | **Linux** | v2rayA / Clash Verge Rev | [v2rayA](https://github.com/v2rayA/v2rayA/releases) / [Clash Verge Rev](https://github.com/clash-verge-rev/clash-verge-rev/releases) |
-| **iOS (Free)** | Streisand | [GitHub](https://github.com/MatsuriDayo/Streisand) |
+| **iOS (Free)** | Streisand / Rocket Proxy | [GitHub](https://github.com/MatsuriDayo/Streisand) / [App Store](https://apps.apple.com/app/id6785291194) |
+| **Apple TV** | Rocket Proxy | [App Store](https://apps.apple.com/app/id6785291194) |
 | **Android** | v2rayNG / Sing-box | [v2rayNG](https://github.com/2dust/v2rayNG/releases) / [Sing-box](https://github.com/SagerNet/sing-box/releases) |
 
 ### Step 3: Paste and connect
@@ -143,6 +144,27 @@ Possible reasons:
 3. Paste the Base64 List link in **URL** field
 4. Tap **Save**, then tap the subscription to update
 5. Select a server and tap the connect button
+</details>
+
+<details>
+<summary><b>Rocket Proxy (iOS / macOS / Apple TV)</b></summary>
+
+**iPhone, iPad, Mac**
+
+1. Install [Rocket Proxy](https://apps.apple.com/app/id6785291194) from the App Store (free)
+2. Open **Servers** → **Import Servers** → **Import from Link**
+3. Paste the Base64 List link and confirm
+4. Use **Update Subscriptions** to refresh later
+5. Select a server and connect
+
+**Apple TV**
+
+Servers are added on iPhone, iPad, or Mac and then sent over — no typing on the TV:
+
+1. On Apple TV: **Servers** → **Add** → **Receive from Nearby Device**
+2. On iPhone/iPad/Mac: **Servers** → **Send to Nearby Device**
+3. The Apple TV appears in the list; confirm to transfer, then connect
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Right-click the link → "Copy link address":
 |--------|-------------------|----------|
 | **Base64 List** | [`https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/all`](https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/all) | v2rayN, v2rayNG, Streisand |
 | **Sing-box JSON** | [`https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/sing-box.json`](https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/sing-box.json) | Sing-box, NekoBox |
-| **Clash YAML** | [`https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml`](https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml) | Clash Verge Rev, ClashX |
+| **Clash YAML** | [`https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml`](https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml) | Clash Verge Rev, ClashX, Rocket Proxy |
 
 <details>
 <summary><b>📋 Copy all links (manual)</b></summary>
@@ -93,7 +93,7 @@ Possible reasons:
 | If your app is... | Use this format |
 |-------------------|-----------------|
 | v2rayN, v2rayNG, v2rayA, Streisand | **Base64 List** |
-| Clash Verge Rev, ClashX | **Clash YAML** |
+| Clash Verge Rev, ClashX, Rocket Proxy | **Clash YAML** |
 | Sing-box | **Sing-box JSON** |
 
 ---
@@ -151,9 +151,9 @@ Possible reasons:
 
 **Mac**
 
-1. Download the [latest `.dmg`](https://github.com/jcltravels/RocketProxy/releases/latest) — free, notarized by Apple, no account required. (Also on the [Mac App Store](https://apps.apple.com/app/id6785291194).)
+1. Download the [latest `.dmg`](https://github.com/jcltravels/RocketProxy/releases/latest) — free, notarized by Apple, universal (Intel and Apple silicon), no account required. (Also on the [Mac App Store](https://apps.apple.com/app/id6785291194).)
 2. Open **Servers** → **Import Servers** → **Import from Link**
-3. Paste the Base64 List link and confirm
+3. Paste the Base64 List **or the Clash YAML** link and confirm
 4. Use **Update Subscriptions** to refresh later
 5. Select a server and connect
 
@@ -161,7 +161,7 @@ Possible reasons:
 
 1. Install [Rocket Proxy](https://apps.apple.com/app/id6785291194) from the App Store (free)
 2. Open **Servers** → **Import Servers** → **Import from Link**
-3. Paste the Base64 List link and confirm
+3. Paste the Base64 List **or the Clash YAML** link and confirm
 4. Use **Update Subscriptions** to refresh later
 5. Select a server and connect
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml
 | Platform | Recommended App | Download |
 |----------|----------------|----------|
 | **Windows** | v2rayN / Clash Verge Rev | [v2rayN](https://github.com/2dust/v2rayN/releases) / [Clash Verge Rev](https://github.com/clash-verge-rev/clash-verge-rev/releases) |
-| **macOS** | Clash Verge Rev / Rocket Proxy | [Clash Verge Rev](https://github.com/clash-verge-rev/clash-verge-rev/releases) / [Rocket Proxy](https://apps.apple.com/app/id6785291194) |
+| **macOS** | Clash Verge Rev / Rocket Proxy | [Clash Verge Rev](https://github.com/clash-verge-rev/clash-verge-rev/releases) / [Rocket Proxy](https://github.com/jcltravels/RocketProxy/releases/latest) |
 | **Linux** | v2rayA / Clash Verge Rev | [v2rayA](https://github.com/v2rayA/v2rayA/releases) / [Clash Verge Rev](https://github.com/clash-verge-rev/clash-verge-rev/releases) |
 | **iOS (Free)** | Streisand / Rocket Proxy | [GitHub](https://github.com/MatsuriDayo/Streisand) / [App Store](https://apps.apple.com/app/id6785291194) |
 | **Apple TV** | Rocket Proxy | [App Store](https://apps.apple.com/app/id6785291194) |
@@ -149,7 +149,15 @@ Possible reasons:
 <details>
 <summary><b>Rocket Proxy (iOS / macOS / Apple TV)</b></summary>
 
-**iPhone, iPad, Mac**
+**Mac**
+
+1. Download the [latest `.dmg`](https://github.com/jcltravels/RocketProxy/releases/latest) — free, notarized by Apple, no account required. (Also on the [Mac App Store](https://apps.apple.com/app/id6785291194).)
+2. Open **Servers** → **Import Servers** → **Import from Link**
+3. Paste the Base64 List link and confirm
+4. Use **Update Subscriptions** to refresh later
+5. Select a server and connect
+
+**iPhone, iPad**
 
 1. Install [Rocket Proxy](https://apps.apple.com/app/id6785291194) from the App Store (free)
 2. Open **Servers** → **Import Servers** → **Import from Link**

--- a/README_CN.md
+++ b/README_CN.md
@@ -43,7 +43,7 @@ https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml
 | 系统 | 推荐软件 | 下载地址 |
 |------|---------|----------|
 | **Windows** | v2rayN / Clash Verge Rev | [v2rayN下载](https://github.com/2dust/v2rayN/releases) / [Clash Verge Rev下载](https://github.com/clash-verge-rev/clash-verge-rev/releases) |
-| **macOS** | Clash Verge Rev / Rocket Proxy | [Clash Verge Rev下载](https://github.com/clash-verge-rev/clash-verge-rev/releases) / [Rocket Proxy](https://apps.apple.com/app/id6785291194) |
+| **macOS** | Clash Verge Rev / Rocket Proxy | [Clash Verge Rev下载](https://github.com/clash-verge-rev/clash-verge-rev/releases) / [Rocket Proxy](https://github.com/jcltravels/RocketProxy/releases/latest) |
 | **Linux** | v2rayA / Clash Verge Rev | [v2rayA下载](https://github.com/v2rayA/v2rayA/releases) / [Clash Verge Rev下载](https://github.com/clash-verge-rev/clash-verge-rev/releases) |
 | **iOS (免费)** | Streisand / Rocket Proxy | [GitHub](https://github.com/MatsuriDayo/Streisand) / [App Store](https://apps.apple.com/app/id6785291194) |
 | **Apple TV** | Rocket Proxy | [App Store](https://apps.apple.com/app/id6785291194) |
@@ -149,7 +149,15 @@ https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml
 <details>
 <summary><b>Rocket Proxy（iOS / macOS / Apple TV）</b></summary>
 
-**iPhone、iPad、Mac**
+**Mac**
+
+1. 下载[最新 `.dmg`](https://github.com/jcltravels/RocketProxy/releases/latest) —— 免费，已通过 Apple 公证，无需账号。（也可从 [Mac App Store](https://apps.apple.com/app/id6785291194) 安装。）
+2. 打开 **Servers** → **Import Servers** → **Import from Link**
+3. 粘贴 Base64 列表链接并确认
+4. 之后可用 **Update Subscriptions** 更新订阅
+5. 选择节点并连接
+
+**iPhone、iPad**
 
 1. 从 App Store 免费安装 [Rocket Proxy](https://apps.apple.com/app/id6785291194)
 2. 打开 **Servers** → **Import Servers** → **Import from Link**

--- a/README_CN.md
+++ b/README_CN.md
@@ -43,9 +43,10 @@ https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml
 | 系统 | 推荐软件 | 下载地址 |
 |------|---------|----------|
 | **Windows** | v2rayN / Clash Verge Rev | [v2rayN下载](https://github.com/2dust/v2rayN/releases) / [Clash Verge Rev下载](https://github.com/clash-verge-rev/clash-verge-rev/releases) |
-| **macOS** | Clash Verge Rev | [Clash Verge Rev下载](https://github.com/clash-verge-rev/clash-verge-rev/releases) |
+| **macOS** | Clash Verge Rev / Rocket Proxy | [Clash Verge Rev下载](https://github.com/clash-verge-rev/clash-verge-rev/releases) / [Rocket Proxy](https://apps.apple.com/app/id6785291194) |
 | **Linux** | v2rayA / Clash Verge Rev | [v2rayA下载](https://github.com/v2rayA/v2rayA/releases) / [Clash Verge Rev下载](https://github.com/clash-verge-rev/clash-verge-rev/releases) |
-| **iOS (免费)** | Streisand | [GitHub](https://github.com/MatsuriDayo/Streisand) |
+| **iOS (免费)** | Streisand / Rocket Proxy | [GitHub](https://github.com/MatsuriDayo/Streisand) / [App Store](https://apps.apple.com/app/id6785291194) |
+| **Apple TV** | Rocket Proxy | [App Store](https://apps.apple.com/app/id6785291194) |
 | **安卓** | v2rayNG / Sing-box | [v2rayNG下载](https://github.com/2dust/v2rayNG/releases) / [Sing-box下载](https://github.com/SagerNet/sing-box/releases) |
 
 ### 第三步：粘贴使用
@@ -143,6 +144,27 @@ https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml
 3. 在 **URL** 栏粘贴Base64 列表链接
 4. 点击 **保存**，然后点击订阅更新
 5. 选择服务器，点击连接按钮
+</details>
+
+<details>
+<summary><b>Rocket Proxy（iOS / macOS / Apple TV）</b></summary>
+
+**iPhone、iPad、Mac**
+
+1. 从 App Store 免费安装 [Rocket Proxy](https://apps.apple.com/app/id6785291194)
+2. 打开 **Servers** → **Import Servers** → **Import from Link**
+3. 粘贴 Base64 列表链接并确认
+4. 之后可用 **Update Subscriptions** 更新订阅
+5. 选择节点并连接
+
+**Apple TV**
+
+节点在 iPhone、iPad 或 Mac 上添加后发送到电视，无需在电视上输入：
+
+1. Apple TV 端：**Servers** → **Add** → **Receive from Nearby Device**
+2. iPhone/iPad/Mac 端：**Servers** → **Send to Nearby Device**
+3. 列表中出现 Apple TV，确认传输后即可连接
+
 </details>
 
 <details>

--- a/README_CN.md
+++ b/README_CN.md
@@ -23,7 +23,7 @@
 |------|----------|-----------|
 | **Base64 列表** | [`https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/all`](https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/all) | v2rayN、v2rayNG、Streisand |
 | **Sing-box JSON** | [`https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/sing-box.json`](https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/sing-box.json) | Sing-box |
-| **Clash YAML** | [`https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml`](https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml) | Clash Verge Rev、ClashX |
+| **Clash YAML** | [`https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml`](https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml) | Clash Verge Rev、ClashX、Rocket Proxy |
 
 <details>
 <summary><b>📋 复制全部链接（手动）</b></summary>
@@ -151,9 +151,9 @@ https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml
 
 **Mac**
 
-1. 下载[最新 `.dmg`](https://github.com/jcltravels/RocketProxy/releases/latest) —— 免费，已通过 Apple 公证，无需账号。（也可从 [Mac App Store](https://apps.apple.com/app/id6785291194) 安装。）
+1. 下载[最新 `.dmg`](https://github.com/jcltravels/RocketProxy/releases/latest) —— 免费，已通过 Apple 公证，通用二进制（Intel 与 Apple 芯片），无需账号。（也可从 [Mac App Store](https://apps.apple.com/app/id6785291194) 安装。）
 2. 打开 **Servers** → **Import Servers** → **Import from Link**
-3. 粘贴 Base64 列表链接并确认
+3. 粘贴 Base64 列表**或 Clash YAML** 链接并确认
 4. 之后可用 **Update Subscriptions** 更新订阅
 5. 选择节点并连接
 
@@ -161,7 +161,7 @@ https://raw.githubusercontent.com/awesome-vpn/awesome-vpn/master/clash.yaml
 
 1. 从 App Store 免费安装 [Rocket Proxy](https://apps.apple.com/app/id6785291194)
 2. 打开 **Servers** → **Import Servers** → **Import from Link**
-3. 粘贴 Base64 列表链接并确认
+3. 粘贴 Base64 列表**或 Clash YAML** 链接并确认
 4. 之后可用 **Update Subscriptions** 更新订阅
 5. 选择节点并连接
 


### PR DESCRIPTION
### What this changes

- Adds **Rocket Proxy** to the client table for **macOS** and **iOS (Free)**, alongside the existing recommendations.
- Adds an **Apple TV** row (the table had no Apple TV entry).
- Adds a setup guide in the same `<details>` style as the existing ones.
- Mirrors all of the above in `README_CN.md`.

### Why

The current list has a couple of gaps for Apple platforms:

- **macOS** only lists Clash Verge Rev.
- The only **iOS** setup guide is Shadowrocket, which is a paid app (~$2.99). The table lists Streisand under "iOS (Free)" but there is no guide for it.
- There is **no Apple TV** option at all.

Rocket Proxy is free on iPhone, iPad, Mac and Apple TV, and imports the Base64 list from this repo directly, so it slots into the existing quick-start flow without changing anything else.

### Notes

- Existing recommendations are **kept** — this adds an option, it does not replace one.
- The Apple TV steps describe the app's actual flow: servers are added on iPhone/iPad/Mac and sent to the TV via **Receive from Nearby Device**, so there is no on-screen typing on the TV.
- App Store listing: https://apps.apple.com/app/id6785291194
- Both files end with a newline, per CONTRIBUTING.

Happy to adjust the wording or drop the setup guide if you would rather keep that section short.
