### PR TITLE
fix: ensure unique sing-box outbound tags

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -78,6 +78,8 @@ jobs:
         [ -s all ] || (echo "ERROR: all is empty" && exit 1)
         [ -s sing-box.json ] || (echo "ERROR: sing-box.json is empty" && exit 1)
         [ -s clash.yaml ] || (echo "ERROR: clash.yaml is empty" && exit 1)
+        [ -x bin/sing-box-linux-amd64 ] || (echo "ERROR: sing-box binary is missing" && exit 1)
+        bin/sing-box-linux-amd64 check -c sing-box.json
         echo "Output sizes:"
         ls -lh all sing-box.json clash.yaml
         NODE_COUNT=$(python -c 'import json; print(len(json.load(open("sing-box.json"))["outbounds"]))')

--- a/core/deduplicator.py
+++ b/core/deduplicator.py
@@ -1,6 +1,50 @@
 import hashlib
 import json
 
+
+def ensure_unique_tags(nodes):
+    """Rename duplicate, non-empty outbound tags in place.
+
+    sing-box requires tags to be unique across outbounds and endpoints. Keep the
+    first occurrence unchanged and suffix later occurrences with `` #N``. Tags
+    already present in the input are reserved so a generated suffix never
+    steals a name from another node.
+
+    Returns the number of renamed nodes.
+    """
+    reserved_tags = {
+        node.get('tag')
+        for node in nodes
+        if isinstance(node.get('tag'), str) and node.get('tag')
+    }
+    used_tags = set()
+    next_suffix = {}
+    renamed = 0
+
+    for node in nodes:
+        tag = node.get('tag')
+        if not isinstance(tag, str) or not tag:
+            continue
+
+        if tag not in used_tags:
+            used_tags.add(tag)
+            next_suffix.setdefault(tag, 2)
+            continue
+
+        suffix = next_suffix.get(tag, 2)
+        candidate = f"{tag} #{suffix}"
+        while candidate in reserved_tags or candidate in used_tags:
+            suffix += 1
+            candidate = f"{tag} #{suffix}"
+
+        node['tag'] = candidate
+        used_tags.add(candidate)
+        next_suffix[tag] = suffix + 1
+        renamed += 1
+
+    return renamed
+
+
 class Deduplicator:
     def __init__(self):
         self.seen_hashes = set()

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ sys.path.append(current_dir)
 sys.path.append(os.path.join(current_dir, 'core', 'parsers'))
 
 from core.spider import Spider
-from core.deduplicator import Deduplicator
+from core.deduplicator import Deduplicator, ensure_unique_tags
 from core.validator import Validator
 from core.binary_manager import BinaryManager
 from core.geo_utils import GeoUtils
@@ -326,7 +326,7 @@ def main():
     # Phase 2: Single-threaded deduplication
     logger.info("Deduplicating nodes...")
     sing_box_outbounds = []
-    link_to_node_map = {}
+    source_links = {}
     duplicates = 0
 
     for node, link in raw_parsed_nodes:
@@ -336,9 +336,8 @@ def main():
             if deduplicator.is_duplicate(n) or deduplicator.is_redundant_server(n):
                 duplicates += 1
                 continue
-            original_tag = n.get('tag', '')
             sing_box_outbounds.append(n)
-            link_to_node_map[original_tag] = link
+            source_links[id(n)] = link
 
     logger.info(f"Successfully parsed: {len(sing_box_outbounds)} nodes")
     logger.info(f"Duplicates filtered: {duplicates}")
@@ -373,27 +372,25 @@ def main():
         logger.info("\nUpdating node names with geo information (parallel)...")
         # Pre-collect data before parallelizing; geo_utils is thread-safe (cached)
         node_data = [
-            (node, node.get('tag', ''), link_to_node_map.get(node.get('tag', ''), ''))
+            (node, node.get('tag', ''))
             for node in valid_nodes
         ]
 
         def resolve_geo(item):
-            node, original_tag, original_link = item
+            node, original_tag = item
             server = node.get('server', '')
             node_name = geo_utils.format_node_name(server) if server else original_tag
-            return node, node_name, original_link
+            return node, node_name
 
         geo_workers = min(50, len(valid_nodes)) if valid_nodes else 1
         with concurrent.futures.ThreadPoolExecutor(max_workers=geo_workers) as executor:
             geo_results = list(executor.map(resolve_geo, node_data))
 
-        updated_link_to_node_map = {}
-        for node, node_name, original_link in geo_results:
+        for node, node_name in geo_results:
             node['tag'] = node_name
-            if original_link:
-                base_link = original_link.rsplit('#', 1)[0] if '#' in original_link else original_link
-                updated_link_to_node_map[node_name] = f"{base_link}#{node_name}"
-        link_to_node_map = updated_link_to_node_map
+
+    renamed_tags = ensure_unique_tags(valid_nodes)
+    logger.info(f"Renamed duplicate tags: {renamed_tags}")
 
     logger.info("\n" + "=" * 60)
     logger.info("Saving output...")
@@ -409,9 +406,10 @@ def main():
     links_output = []
     for node in valid_nodes:
         tag = node.get('tag', '')
-        original_link = link_to_node_map.get(tag, '')
+        original_link = source_links.get(id(node), '')
         if original_link:
-            links_output.append(original_link)
+            base_link = original_link.rsplit('#', 1)[0] if '#' in original_link else original_link
+            links_output.append(f"{base_link}#{tag}")
         else:
             server = node.get('server', '')
             port = node.get('server_port') or node.get('port', '')

--- a/sing-box.json
+++ b/sing-box.json
@@ -80,7 +80,7 @@
       "password": "k1dBOmOB4oqi7Ump37a1bQ"
     },
     {
-      "tag": "美国/United States",
+      "tag": "美国/United States #2",
       "type": "vless",
       "server": "31.58.50.200",
       "server_port": 8443,
@@ -137,7 +137,7 @@
       }
     },
     {
-      "tag": "德国/Germany",
+      "tag": "德国/Germany #2",
       "type": "vless",
       "server": "169.40.42.173",
       "server_port": 443,
@@ -168,7 +168,7 @@
       "packet_encoding": "xudp"
     },
     {
-      "tag": "美国/阿什本/United States/Ashburn",
+      "tag": "美国/阿什本/United States/Ashburn #2",
       "type": "shadowsocks",
       "server": "autodiscover.fuzzyaytor.cyou",
       "server_port": 42982,
@@ -217,7 +217,7 @@
       }
     },
     {
-      "tag": "英国/United Kingdom",
+      "tag": "英国/United Kingdom #2",
       "type": "shadowsocks",
       "server": "82.38.31.2",
       "server_port": 8080,
@@ -247,7 +247,7 @@
       }
     },
     {
-      "tag": "美国/San Francisco/United States/San Francisco",
+      "tag": "美国/San Francisco/United States/San Francisco #2",
       "type": "vmess",
       "server": "104.17.77.77",
       "server_port": 8443,
@@ -291,7 +291,7 @@
       }
     },
     {
-      "tag": "美国/United States",
+      "tag": "美国/United States #3",
       "type": "shadowsocks",
       "server": "23.150.248.20",
       "server_port": 8388,
@@ -299,7 +299,7 @@
       "password": "qB2Cv9VIlujj"
     },
     {
-      "tag": "美国/United States",
+      "tag": "美国/United States #4",
       "type": "trojan",
       "server": "151.101.56.0",
       "server_port": 443,
@@ -325,7 +325,7 @@
       }
     },
     {
-      "tag": "英国/United Kingdom",
+      "tag": "英国/United Kingdom #3",
       "type": "vless",
       "server": "144.31.213.150",
       "server_port": 443,
@@ -347,7 +347,7 @@
       }
     },
     {
-      "tag": "香港/香港/Hong Kong/Hong Kong",
+      "tag": "香港/香港/Hong Kong/Hong Kong #2",
       "type": "vmess",
       "server": "n1747624260.4u9ma.icu",
       "server_port": 443,
@@ -392,7 +392,7 @@
       }
     },
     {
-      "tag": "美国/洛杉矶/United States/Los Angeles",
+      "tag": "美国/洛杉矶/United States/Los Angeles #2",
       "type": "vless",
       "server": "70.39.197.9",
       "server_port": 59216,
@@ -400,7 +400,7 @@
       "packet_encoding": "xudp"
     },
     {
-      "tag": "香港/香港/Hong Kong/Hong Kong",
+      "tag": "香港/香港/Hong Kong/Hong Kong #3",
       "type": "vmess",
       "server": "6jdvarazgu3qqr6q.v.3dns.vip",
       "server_port": 443,
@@ -422,7 +422,7 @@
       }
     },
     {
-      "tag": "美国/洛杉矶/United States/Los Angeles",
+      "tag": "美国/洛杉矶/United States/Los Angeles #3",
       "type": "shadowsocks",
       "server": "70.39.178.204",
       "server_port": 42747,
@@ -440,7 +440,7 @@
       "packet_encoding": "xudp"
     },
     {
-      "tag": "芬兰/赫尔辛基/Finland/Helsinki",
+      "tag": "芬兰/赫尔辛基/Finland/Helsinki #2",
       "type": "vless",
       "server": "65.109.220.7",
       "server_port": 57024,
@@ -478,7 +478,7 @@
       "packet_encoding": "xudp"
     },
     {
-      "tag": "芬兰/赫尔辛基/Finland/Helsinki",
+      "tag": "芬兰/赫尔辛基/Finland/Helsinki #3",
       "type": "shadowsocks",
       "server": "31.76.30.79",
       "server_port": 10808,
@@ -540,7 +540,7 @@
       }
     },
     {
-      "tag": "美国/San Francisco/United States/San Francisco",
+      "tag": "美国/San Francisco/United States/San Francisco #3",
       "type": "vmess",
       "server": "rush-72frf.meeopp.site",
       "server_port": 443,
@@ -562,7 +562,7 @@
       }
     },
     {
-      "tag": "美国/United States",
+      "tag": "美国/United States #5",
       "type": "vless",
       "server": "47.89.186.170",
       "server_port": 55861,
@@ -597,7 +597,7 @@
       }
     },
     {
-      "tag": "美国/洛杉矶/United States/Los Angeles",
+      "tag": "美国/洛杉矶/United States/Los Angeles #4",
       "type": "vless",
       "server": "194.55.189.249",
       "server_port": 40443,
@@ -618,7 +618,7 @@
       }
     },
     {
-      "tag": "香港/香港/Hong Kong/Hong Kong",
+      "tag": "香港/香港/Hong Kong/Hong Kong #4",
       "type": "vmess",
       "server": "ce0gedpxwou6cqon.v.3dns.vip",
       "server_port": 443,
@@ -655,7 +655,7 @@
       }
     },
     {
-      "tag": "美国/United States",
+      "tag": "美国/United States #6",
       "type": "vmess",
       "server": "165.140.216.142",
       "server_port": 443,
@@ -673,7 +673,7 @@
       "password": "1hhrqrokj3ag"
     },
     {
-      "tag": "新加坡/新加坡/Singapore/Singapore",
+      "tag": "新加坡/新加坡/Singapore/Singapore #2",
       "type": "shadowsocks",
       "server": "167.150.100.115",
       "server_port": 27755,
@@ -703,7 +703,7 @@
       }
     },
     {
-      "tag": "美国/San Francisco/United States/San Francisco",
+      "tag": "美国/San Francisco/United States/San Francisco #4",
       "type": "vless",
       "server": "8.39.125.152",
       "server_port": 8443,
@@ -745,7 +745,7 @@
       }
     },
     {
-      "tag": "法国/France",
+      "tag": "法国/France #2",
       "type": "vless",
       "server": "162.19.10.99",
       "server_port": 443,
@@ -776,7 +776,7 @@
       }
     },
     {
-      "tag": "荷兰/哈勒姆/The Netherlands/Haarlem",
+      "tag": "荷兰/哈勒姆/The Netherlands/Haarlem #2",
       "type": "vless",
       "server": "mypanel.unixzone.us",
       "server_port": 12068,
@@ -791,7 +791,7 @@
       }
     },
     {
-      "tag": "芬兰/赫尔辛基/Finland/Helsinki",
+      "tag": "芬兰/赫尔辛基/Finland/Helsinki #4",
       "type": "vless",
       "server": "95.85.251.116",
       "server_port": 59631,
@@ -816,7 +816,7 @@
       }
     },
     {
-      "tag": "加拿大/Canada",
+      "tag": "加拿大/Canada #2",
       "type": "shadowsocks",
       "server": "15.235.75.71",
       "server_port": 8388,
@@ -840,7 +840,7 @@
       "password": "bIOoi5TuImG2KccxV7-jcA7Cez+vun-c_E"
     },
     {
-      "tag": "美国/United States",
+      "tag": "美国/United States #7",
       "type": "vless",
       "server": "208.103.161.32",
       "server_port": 443,
@@ -860,7 +860,7 @@
       }
     },
     {
-      "tag": "香港/香港/Hong Kong/Hong Kong",
+      "tag": "香港/香港/Hong Kong/Hong Kong #5",
       "type": "vmess",
       "server": "47.244.120.197",
       "server_port": 44867,
@@ -874,7 +874,7 @@
       }
     },
     {
-      "tag": "美国/San Francisco/United States/San Francisco",
+      "tag": "美国/San Francisco/United States/San Francisco #5",
       "type": "vless",
       "server": "104.16.27.134",
       "server_port": 80,
@@ -910,7 +910,7 @@
       }
     },
     {
-      "tag": "香港/香港/Hong Kong/Hong Kong",
+      "tag": "香港/香港/Hong Kong/Hong Kong #6",
       "type": "vmess",
       "server": "47.244.120.197",
       "server_port": 36703,
@@ -926,7 +926,7 @@
       }
     },
     {
-      "tag": "美国/United States",
+      "tag": "美国/United States #8",
       "type": "shadowsocks",
       "server": "38.180.135.156",
       "server_port": 8388,
@@ -934,7 +934,7 @@
       "password": "YHtesZ0qvgtg"
     },
     {
-      "tag": "加拿大/多伦多/Canada/Toronto",
+      "tag": "加拿大/多伦多/Canada/Toronto #2",
       "type": "shadowsocks",
       "server": "137.184.174.93",
       "server_port": 8080,
@@ -942,7 +942,7 @@
       "password": "14fFPrbezE3HDZzsMOr6"
     },
     {
-      "tag": "塞舌尔/Seychelles",
+      "tag": "塞舌尔/Seychelles #2",
       "type": "vless",
       "server": "45.145.56.163",
       "server_port": 443,
@@ -964,7 +964,7 @@
       }
     },
     {
-      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam",
+      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam #2",
       "type": "vless",
       "server": "72.56.81.165",
       "server_port": 40443,
@@ -1011,7 +1011,7 @@
       }
     },
     {
-      "tag": "波兰/华沙/Poland/Warsaw",
+      "tag": "波兰/华沙/Poland/Warsaw #2",
       "type": "vless",
       "server": "82.26.91.87",
       "server_port": 443,
@@ -1025,7 +1025,7 @@
       }
     },
     {
-      "tag": "德国/法兰克福/Germany/Frankfurt am Main",
+      "tag": "德国/法兰克福/Germany/Frankfurt am Main #2",
       "type": "vmess",
       "server": "deapp.jisuyun.top",
       "server_port": 2053,
@@ -1052,7 +1052,7 @@
       "password": "ARgvGZywA+gacgGV26Bvmu05+wZmRW/j+AdU+Z8Bt44="
     },
     {
-      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam",
+      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam #3",
       "type": "shadowsocks",
       "server": "92.112.126.90",
       "server_port": 443,
@@ -1077,7 +1077,7 @@
       }
     },
     {
-      "tag": "法国/France",
+      "tag": "法国/France #3",
       "type": "shadowsocks",
       "server": "51.77.225.200",
       "server_port": 8388,
@@ -1085,7 +1085,7 @@
       "password": "zRZNBszYyWo5"
     },
     {
-      "tag": "日本/东京/Japan/Tokyo",
+      "tag": "日本/东京/Japan/Tokyo #2",
       "type": "shadowsocks",
       "server": "176.97.73.215",
       "server_port": 8388,
@@ -1093,7 +1093,7 @@
       "password": "ma6zc4JoLRJA"
     },
     {
-      "tag": "西班牙/巴塞罗那/Spain/Barcelona",
+      "tag": "西班牙/巴塞罗那/Spain/Barcelona #2",
       "type": "shadowsocks",
       "server": "108.181.121.226",
       "server_port": 8388,
@@ -1101,7 +1101,7 @@
       "password": "WSyL4XTwNsdv"
     },
     {
-      "tag": "德国/Germany",
+      "tag": "德国/Germany #3",
       "type": "vless",
       "server": "77.239.123.219",
       "server_port": 443,
@@ -1123,7 +1123,7 @@
       }
     },
     {
-      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam",
+      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam #4",
       "type": "shadowsocks",
       "server": "188.116.23.244",
       "server_port": 8388,
@@ -1131,7 +1131,7 @@
       "password": "eVC634QvVk5l"
     },
     {
-      "tag": "法国/France",
+      "tag": "法国/France #4",
       "type": "vless",
       "server": "fr199.mechvpn.online",
       "server_port": 443,
@@ -1145,7 +1145,7 @@
       }
     },
     {
-      "tag": "德国/Germany",
+      "tag": "德国/Germany #4",
       "type": "shadowsocks",
       "server": "91.107.139.186",
       "server_port": 31330,
@@ -1197,7 +1197,7 @@
       }
     },
     {
-      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam",
+      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam #5",
       "type": "shadowsocks",
       "server": "switcher-nick-croquet.freesocks.work",
       "server_port": 443,
@@ -1215,7 +1215,7 @@
       "packet_encoding": "xudp"
     },
     {
-      "tag": "美国/San Francisco/United States/San Francisco",
+      "tag": "美国/San Francisco/United States/San Francisco #6",
       "type": "vless",
       "server": "one-for-all.levikogjgfdd.ir",
       "server_port": 2053,
@@ -1235,7 +1235,7 @@
       }
     },
     {
-      "tag": "香港/香港/Hong Kong/Hong Kong",
+      "tag": "香港/香港/Hong Kong/Hong Kong #7",
       "type": "vmess",
       "server": "154.37.223.56",
       "server_port": 52080,
@@ -1249,7 +1249,7 @@
       }
     },
     {
-      "tag": "美国/United States",
+      "tag": "美国/United States #9",
       "type": "vless",
       "server": "47.253.226.114",
       "server_port": 443,
@@ -1270,7 +1270,7 @@
       }
     },
     {
-      "tag": "美国/San Francisco/United States/San Francisco",
+      "tag": "美国/San Francisco/United States/San Francisco #7",
       "type": "vless",
       "server": "hi.n2foriran.workers.dev",
       "server_port": 443,
@@ -1313,7 +1313,7 @@
       }
     },
     {
-      "tag": "保加利亚/Bulgaria",
+      "tag": "保加利亚/Bulgaria #2",
       "type": "shadowsocks",
       "server": "93.123.13.7",
       "server_port": 25783,
@@ -1321,7 +1321,7 @@
       "password": "8cmuvza9gyetx0z8"
     },
     {
-      "tag": "荷兰/The Netherlands",
+      "tag": "荷兰/The Netherlands #2",
       "type": "shadowsocks",
       "server": "193.29.139.168",
       "server_port": 8080,
@@ -1351,7 +1351,7 @@
       }
     },
     {
-      "tag": "德国/Germany",
+      "tag": "德国/Germany #5",
       "type": "shadowsocks",
       "server": "51.195.126.38",
       "server_port": 8388,
@@ -1369,7 +1369,7 @@
       "packet_encoding": "xudp"
     },
     {
-      "tag": "美国/San Francisco/United States/San Francisco",
+      "tag": "美国/San Francisco/United States/San Francisco #8",
       "type": "vless",
       "server": "172.67.69.106",
       "server_port": 443,
@@ -1389,7 +1389,7 @@
       }
     },
     {
-      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam",
+      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam #6",
       "type": "vless",
       "server": "72.56.92.177",
       "server_port": 40443,
@@ -1411,7 +1411,7 @@
       }
     },
     {
-      "tag": "美国/洛杉矶/United States/Los Angeles",
+      "tag": "美国/洛杉矶/United States/Los Angeles #5",
       "type": "shadowsocks",
       "server": "216.105.168.18",
       "server_port": 443,
@@ -1419,7 +1419,7 @@
       "password": "hCCWOcIsK5wrFz4OX70rWf"
     },
     {
-      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam",
+      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam #7",
       "type": "vless",
       "server": "144.124.246.55",
       "server_port": 443,
@@ -1442,7 +1442,7 @@
       }
     },
     {
-      "tag": "保加利亚/Bulgaria",
+      "tag": "保加利亚/Bulgaria #3",
       "type": "vless",
       "server": "93.123.13.7",
       "server_port": 15139,
@@ -1458,7 +1458,7 @@
       "password": "uTBjZhDmOMwBVAJI"
     },
     {
-      "tag": "香港/香港/Hong Kong/Hong Kong",
+      "tag": "香港/香港/Hong Kong/Hong Kong #8",
       "type": "vmess",
       "server": "zudssgtmrqg9lpvi.v.3dns.vip",
       "server_port": 443,
@@ -1492,7 +1492,7 @@
       }
     },
     {
-      "tag": "日本/东京/Japan/Tokyo",
+      "tag": "日本/东京/Japan/Tokyo #3",
       "type": "vmess",
       "server": "207.56.229.202",
       "server_port": 2052,
@@ -1509,7 +1509,7 @@
       }
     },
     {
-      "tag": "美国/United States",
+      "tag": "美国/United States #10",
       "type": "vless",
       "server": "180.178.60.253",
       "server_port": 10000,
@@ -1517,7 +1517,7 @@
       "packet_encoding": "xudp"
     },
     {
-      "tag": "德国/Germany",
+      "tag": "德国/Germany #6",
       "type": "vless",
       "server": "91.107.139.186",
       "server_port": 27495,
@@ -1525,7 +1525,7 @@
       "packet_encoding": "xudp"
     },
     {
-      "tag": "马来西亚/吉隆坡/Malaysia/Kuala Lumpur",
+      "tag": "马来西亚/吉隆坡/Malaysia/Kuala Lumpur #2",
       "type": "vmess",
       "server": "47.250.45.234",
       "server_port": 8613,
@@ -1541,7 +1541,7 @@
       }
     },
     {
-      "tag": "芬兰/赫尔辛基/Finland/Helsinki",
+      "tag": "芬兰/赫尔辛基/Finland/Helsinki #5",
       "type": "vless",
       "server": "185.79.138.71",
       "server_port": 448,
@@ -1589,7 +1589,7 @@
       }
     },
     {
-      "tag": "美国/洛杉矶/United States/Los Angeles",
+      "tag": "美国/洛杉矶/United States/Los Angeles #6",
       "type": "vless",
       "server": "192.204.33.111",
       "server_port": 56679,
@@ -1612,7 +1612,7 @@
       }
     },
     {
-      "tag": "德国/法兰克福/Germany/Frankfurt am Main",
+      "tag": "德国/法兰克福/Germany/Frankfurt am Main #3",
       "type": "vless",
       "server": "185.126.67.76",
       "server_port": 443,
@@ -1668,7 +1668,7 @@
       }
     },
     {
-      "tag": "美国/United States",
+      "tag": "美国/United States #11",
       "type": "vless",
       "server": "184.168.47.50",
       "server_port": 8880,
@@ -1685,7 +1685,7 @@
       }
     },
     {
-      "tag": "美国/San Francisco/United States/San Francisco",
+      "tag": "美国/San Francisco/United States/San Francisco #9",
       "type": "vless",
       "server": "104.27.124.133",
       "server_port": 80,
@@ -1700,7 +1700,7 @@
       }
     },
     {
-      "tag": "法国/France",
+      "tag": "法国/France #5",
       "type": "vless",
       "server": "213.136.92.67",
       "server_port": 443,
@@ -1748,7 +1748,7 @@
       }
     },
     {
-      "tag": "德国/法兰克福/Germany/Frankfurt am Main",
+      "tag": "德国/法兰克福/Germany/Frankfurt am Main #4",
       "type": "vless",
       "server": "87.120.126.63",
       "server_port": 8443,
@@ -1774,7 +1774,7 @@
       }
     },
     {
-      "tag": "英国/United Kingdom",
+      "tag": "英国/United Kingdom #4",
       "type": "vless",
       "server": "144.31.213.225",
       "server_port": 443,
@@ -1796,7 +1796,7 @@
       }
     },
     {
-      "tag": "美国/United States",
+      "tag": "美国/United States #12",
       "type": "shadowsocks",
       "server": "198.98.53.130",
       "server_port": 443,
@@ -1804,7 +1804,7 @@
       "password": "eDfN7SODQceIOmIAbtJJtK"
     },
     {
-      "tag": "英国/United Kingdom",
+      "tag": "英国/United Kingdom #5",
       "type": "shadowsocks",
       "server": "104.249.22.75",
       "server_port": 43377,
@@ -1847,7 +1847,7 @@
       }
     },
     {
-      "tag": "美国/United States",
+      "tag": "美国/United States #13",
       "type": "shadowsocks",
       "server": "47.88.85.254",
       "server_port": 23226,
@@ -1855,7 +1855,7 @@
       "password": "5jfrMoSGPSR1FqwTFtpc8g=="
     },
     {
-      "tag": "俄罗斯联邦/莫斯科/Russia/Moscow",
+      "tag": "俄罗斯联邦/莫斯科/Russia/Moscow #2",
       "type": "vless",
       "server": "201.51.5.253",
       "server_port": 2200,
@@ -1870,7 +1870,7 @@
       }
     },
     {
-      "tag": "韩国/首尔特别市/South Korea/Seoul",
+      "tag": "韩国/首尔特别市/South Korea/Seoul #2",
       "type": "vmess",
       "server": "217.142.138.61",
       "server_port": 80,
@@ -1883,7 +1883,7 @@
       }
     },
     {
-      "tag": "塞浦路斯/Cyprus",
+      "tag": "塞浦路斯/Cyprus #2",
       "type": "vless",
       "server": "5.253.42.164",
       "server_port": 40443,
@@ -1906,7 +1906,7 @@
       }
     },
     {
-      "tag": "保加利亚/Bulgaria",
+      "tag": "保加利亚/Bulgaria #4",
       "type": "shadowsocks",
       "server": "93.123.13.7",
       "server_port": 16460,
@@ -1914,7 +1914,7 @@
       "password": "8yezd40lr2w4zz08"
     },
     {
-      "tag": "保加利亚/Bulgaria",
+      "tag": "保加利亚/Bulgaria #5",
       "type": "vless",
       "server": "93.123.13.7",
       "server_port": 15755,
@@ -1942,7 +1942,7 @@
       }
     },
     {
-      "tag": "美国/San Francisco/United States/San Francisco",
+      "tag": "美国/San Francisco/United States/San Francisco #10",
       "type": "vless",
       "server": "104.16.98.215",
       "server_port": 8880,
@@ -1957,7 +1957,7 @@
       }
     },
     {
-      "tag": "荷兰/The Netherlands",
+      "tag": "荷兰/The Netherlands #3",
       "type": "vless",
       "server": "188.164.248.69",
       "server_port": 443,
@@ -1977,7 +1977,7 @@
       }
     },
     {
-      "tag": "美国/San Francisco/United States/San Francisco",
+      "tag": "美国/San Francisco/United States/San Francisco #11",
       "type": "vmess",
       "server": "rush-w1niu.teeopp.online",
       "server_port": 443,
@@ -1999,7 +1999,7 @@
       }
     },
     {
-      "tag": "美国/洛杉矶/United States/Los Angeles",
+      "tag": "美国/洛杉矶/United States/Los Angeles #7",
       "type": "vless",
       "server": "70.39.197.13",
       "server_port": 46197,
@@ -2021,7 +2021,7 @@
       }
     },
     {
-      "tag": "德国/法兰克福/Germany/Frankfurt am Main",
+      "tag": "德国/法兰克福/Germany/Frankfurt am Main #5",
       "type": "vless",
       "server": "api.noneok.com",
       "server_port": 443,
@@ -2046,7 +2046,7 @@
       }
     },
     {
-      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam",
+      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam #8",
       "type": "shadowsocks",
       "server": "108.181.126.122",
       "server_port": 8388,
@@ -2083,7 +2083,7 @@
       }
     },
     {
-      "tag": "新加坡/新加坡/Singapore/Singapore",
+      "tag": "新加坡/新加坡/Singapore/Singapore #3",
       "type": "shadowsocks",
       "server": "176.97.64.144",
       "server_port": 8388,
@@ -2099,7 +2099,7 @@
       "password": "tfAcRikawhNoZAhu"
     },
     {
-      "tag": "美国/San Francisco/United States/San Francisco",
+      "tag": "美国/San Francisco/United States/San Francisco #12",
       "type": "vless",
       "server": "104.26.1.195",
       "server_port": 8080,
@@ -2122,7 +2122,7 @@
       "password": "pFNN9jKe8jwD"
     },
     {
-      "tag": "美国/San Francisco/United States/San Francisco",
+      "tag": "美国/San Francisco/United States/San Francisco #13",
       "type": "vless",
       "server": "ytryurdj64bbb.localip.ir",
       "server_port": 443,
@@ -2190,7 +2190,7 @@
       "password": "Xsy8Ox4yOV3xLlpxtjzs3X"
     },
     {
-      "tag": "新加坡/新加坡/Singapore/Singapore",
+      "tag": "新加坡/新加坡/Singapore/Singapore #4",
       "type": "vless",
       "server": "178.128.112.70",
       "server_port": 443,
@@ -2213,7 +2213,7 @@
       }
     },
     {
-      "tag": "德国/法兰克福/Germany/Frankfurt am Main",
+      "tag": "德国/法兰克福/Germany/Frankfurt am Main #6",
       "type": "hysteria2",
       "server": "social.klipp.su",
       "server_port": 443,
@@ -2234,7 +2234,7 @@
       }
     },
     {
-      "tag": "俄罗斯联邦/莫斯科/Russia/Moscow",
+      "tag": "俄罗斯联邦/莫斯科/Russia/Moscow #3",
       "type": "vless",
       "server": "201.51.5.253",
       "server_port": 4100,
@@ -2249,7 +2249,7 @@
       }
     },
     {
-      "tag": "芬兰/赫尔辛基/Finland/Helsinki",
+      "tag": "芬兰/赫尔辛基/Finland/Helsinki #6",
       "type": "hysteria2",
       "server": "musicclips.videolinks.ru",
       "server_port": 8443,
@@ -2270,7 +2270,7 @@
       }
     },
     {
-      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam",
+      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam #9",
       "type": "hysteria2",
       "server": "86.107.178.69",
       "server_port": 8443,
@@ -2287,7 +2287,7 @@
       }
     },
     {
-      "tag": "法国/巴黎/France/Paris",
+      "tag": "法国/巴黎/France/Paris #2",
       "type": "hysteria2",
       "server": "iq5ny.pleiades.codes",
       "server_port": 8443,
@@ -2304,7 +2304,7 @@
       }
     },
     {
-      "tag": "芬兰/赫尔辛基/Finland/Helsinki",
+      "tag": "芬兰/赫尔辛基/Finland/Helsinki #7",
       "type": "hysteria2",
       "server": "2.26.97.21",
       "server_port": 8443,
@@ -2325,7 +2325,7 @@
       }
     },
     {
-      "tag": "爱沙尼亚/Estonia",
+      "tag": "爱沙尼亚/Estonia #2",
       "type": "vless",
       "server": "185.155.97.58",
       "server_port": 45176,
@@ -2382,7 +2382,7 @@
       }
     },
     {
-      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam",
+      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam #10",
       "type": "hysteria2",
       "server": "nl1.noesissite.ru",
       "server_port": 443,
@@ -2399,7 +2399,7 @@
       }
     },
     {
-      "tag": "罗马尼亚/Romania",
+      "tag": "罗马尼亚/Romania #2",
       "type": "hysteria2",
       "server": "205.237.109.221",
       "server_port": 8443,
@@ -2416,7 +2416,7 @@
       }
     },
     {
-      "tag": "德国/法兰克福/Germany/Frankfurt am Main",
+      "tag": "德国/法兰克福/Germany/Frankfurt am Main #7",
       "type": "hysteria2",
       "server": "103.27.156.125",
       "server_port": 443,
@@ -2433,7 +2433,7 @@
       }
     },
     {
-      "tag": "德国/法兰克福/Germany/Frankfurt am Main",
+      "tag": "德国/法兰克福/Germany/Frankfurt am Main #8",
       "type": "hysteria2",
       "server": "node-degame.bangboonet.ru",
       "server_port": 443,
@@ -2450,7 +2450,7 @@
       }
     },
     {
-      "tag": "荷兰/The Netherlands",
+      "tag": "荷兰/The Netherlands #4",
       "type": "hysteria2",
       "server": "nl2.sferavpn.pro",
       "server_port": 443,
@@ -2471,7 +2471,7 @@
       }
     },
     {
-      "tag": "波兰/华沙/Poland/Warsaw",
+      "tag": "波兰/华沙/Poland/Warsaw #3",
       "type": "hysteria2",
       "server": "pl6.lckdwn.ru",
       "server_port": 443,
@@ -2492,7 +2492,7 @@
       }
     },
     {
-      "tag": "俄罗斯联邦/莫斯科/Russia/Moscow",
+      "tag": "俄罗斯联邦/莫斯科/Russia/Moscow #4",
       "type": "hysteria2",
       "server": "138.124.68.188",
       "server_port": 443,
@@ -2509,7 +2509,7 @@
       }
     },
     {
-      "tag": "德国/Germany",
+      "tag": "德国/Germany #7",
       "type": "hysteria2",
       "server": "91.107.176.41",
       "server_port": 2082,
@@ -2530,7 +2530,7 @@
       }
     },
     {
-      "tag": "中国/China",
+      "tag": "中国/China #2",
       "type": "hysteria2",
       "server": "167.179.34.13",
       "server_port": 55443,
@@ -2547,7 +2547,7 @@
       }
     },
     {
-      "tag": "日本/东京/Japan/Tokyo",
+      "tag": "日本/东京/Japan/Tokyo #4",
       "type": "hysteria2",
       "server": "207.56.227.226",
       "server_port": 48920,
@@ -2564,7 +2564,7 @@
       }
     },
     {
-      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam",
+      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam #11",
       "type": "hysteria2",
       "server": "86.107.178.66",
       "server_port": 8443,
@@ -2581,7 +2581,7 @@
       }
     },
     {
-      "tag": "香港/Hong Kong",
+      "tag": "香港/Hong Kong #2",
       "type": "hysteria2",
       "server": "202.146.222.29",
       "server_port": 443,
@@ -2597,7 +2597,7 @@
       }
     },
     {
-      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam",
+      "tag": "荷兰/阿姆斯特丹/The Netherlands/Amsterdam #12",
       "type": "hysteria2",
       "server": "193.23.194.78",
       "server_port": 443,
@@ -2614,7 +2614,7 @@
       }
     },
     {
-      "tag": "法国/巴黎/France/Paris",
+      "tag": "法国/巴黎/France/Paris #3",
       "type": "hysteria2",
       "server": "151.247.193.5",
       "server_port": 8443,
@@ -2631,7 +2631,7 @@
       }
     },
     {
-      "tag": "罗马尼亚/Romania",
+      "tag": "罗马尼亚/Romania #3",
       "type": "hysteria2",
       "server": "205.237.109.220",
       "server_port": 8443,
@@ -2648,7 +2648,7 @@
       }
     },
     {
-      "tag": "新加坡/新加坡/Singapore/Singapore",
+      "tag": "新加坡/新加坡/Singapore/Singapore #5",
       "type": "hysteria2",
       "server": "140.99.130.34",
       "server_port": 4466,
@@ -2665,7 +2665,7 @@
       }
     },
     {
-      "tag": "日本/东京/Japan/Tokyo",
+      "tag": "日本/东京/Japan/Tokyo #5",
       "type": "hysteria2",
       "server": "freedom.chenlan.top",
       "server_port": 12765,
@@ -2682,7 +2682,7 @@
       }
     },
     {
-      "tag": "罗马尼亚/Romania",
+      "tag": "罗马尼亚/Romania #4",
       "type": "hysteria2",
       "server": "205.237.109.219",
       "server_port": 8443,
@@ -2699,7 +2699,7 @@
       }
     },
     {
-      "tag": "法国/巴黎/France/Paris",
+      "tag": "法国/巴黎/France/Paris #4",
       "type": "hysteria2",
       "server": "host-vds2-fr.kvncococ.org",
       "server_port": 55443,
@@ -2716,7 +2716,7 @@
       }
     },
     {
-      "tag": "波兰/华沙/Poland/Warsaw",
+      "tag": "波兰/华沙/Poland/Warsaw #4",
       "type": "hysteria2",
       "server": "82.22.41.125",
       "server_port": 443,
@@ -2737,7 +2737,7 @@
       }
     },
     {
-      "tag": "台湾/台北市/Taiwan/Taipei",
+      "tag": "台湾/台北市/Taiwan/Taipei #2",
       "type": "hysteria2",
       "server": "103.115.109.49",
       "server_port": 443,
@@ -2754,7 +2754,7 @@
       }
     },
     {
-      "tag": "罗马尼亚/Romania",
+      "tag": "罗马尼亚/Romania #5",
       "type": "hysteria2",
       "server": "205.237.109.216",
       "server_port": 8443,
@@ -2771,7 +2771,7 @@
       }
     },
     {
-      "tag": "美国/洛杉矶/United States/Los Angeles",
+      "tag": "美国/洛杉矶/United States/Los Angeles #8",
       "type": "hysteria2",
       "server": "155.117.19.221",
       "server_port": 30001,
@@ -2787,7 +2787,7 @@
       }
     },
     {
-      "tag": "芬兰/赫尔辛基/Finland/Helsinki",
+      "tag": "芬兰/赫尔辛基/Finland/Helsinki #8",
       "type": "hysteria2",
       "server": "185.79.138.71",
       "server_port": 8443,

--- a/tests/test_deduplicator.py
+++ b/tests/test_deduplicator.py
@@ -1,0 +1,48 @@
+from core.deduplicator import ensure_unique_tags
+
+
+def test_ensure_unique_tags_suffixes_duplicate_names():
+    nodes = [
+        {"tag": "美国/United States"},
+        {"tag": "美国/United States"},
+        {"tag": "美国/United States"},
+    ]
+
+    renamed = ensure_unique_tags(nodes)
+
+    assert renamed == 2
+    assert [node["tag"] for node in nodes] == [
+        "美国/United States",
+        "美国/United States #2",
+        "美国/United States #3",
+    ]
+
+
+def test_ensure_unique_tags_reserves_existing_suffixes():
+    nodes = [
+        {"tag": "US"},
+        {"tag": "US"},
+        {"tag": "US #2"},
+    ]
+
+    ensure_unique_tags(nodes)
+
+    assert [node["tag"] for node in nodes] == ["US", "US #3", "US #2"]
+
+
+def test_ensure_unique_tags_is_idempotent_and_ignores_empty_tags():
+    nodes = [
+        {"tag": "US"},
+        {"tag": "US #2"},
+        {"tag": ""},
+        {},
+    ]
+
+    assert ensure_unique_tags(nodes) == 0
+    assert ensure_unique_tags(nodes) == 0
+    assert nodes == [
+        {"tag": "US"},
+        {"tag": "US #2"},
+        {"tag": ""},
+        {},
+    ]


### PR DESCRIPTION
## Description

The crawler replaces node tags with GeoIP location names after validating each node. Multiple valid nodes in the same location therefore receive identical tags, and sing-box rejects the generated profile with errors such as:

```
decode config: duplicate outbound/endpoint tag: 美国/United States
```

This change:

- keeps the first occurrence of each tag unchanged and assigns deterministic ` #2`, ` #3`, ... suffixes to later occurrences;
- reserves existing suffixed tags to avoid introducing a new collision;
- keeps source links associated with their node after tags are renamed;
- runs `sing-box check` on the complete generated profile before committing it.

Fixes #119

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `uv run --with pytest pytest -q` — 24 passed
- [x] Applied `ensure_unique_tags` to the current `sing-box.json` — 177 outbounds, 118 renamed, 177 unique tags
- [x] `sing-box check -c /tmp/awesome-vpn-sing-box-fixed.json` — passed with sing-box 1.13.11

**Test Configuration**:
* Python version: 3.14.3
* Operating System: macOS 15 (arm64)
* sing-box version: 1.13.11

## Checklist

- [x] My code follows the style guidelines of this project (PEP 8)
- [x] I have performed a self-review of my own code
- [x] I have commented the non-obvious collision handling
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing unit tests pass locally with my changes

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the GNU GPL v3 license.
